### PR TITLE
Allow relative callback_urls

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Dancer-Plugin-Auth-Google
 
+0.07    t.b.d.
+    - Callback url may now adopt to URL used for the current request
+
 0.06    2014-12-27
     - added missing prereq.
 


### PR DESCRIPTION
The development (or live) system might be accessible using different URLs. This patch allows a relative callback_url value which adopts to the current requests host. This is dangerous, because all values passed to Google must be registered there, but I also added a warning to the POD.
